### PR TITLE
fix training: resolve SVM convergence warning

### DIFF
--- a/dplp_parser/model.py
+++ b/dplp_parser/model.py
@@ -38,7 +38,7 @@ class ParsingModel(object):
         self.labelmap = idxlabelmap
         if clf is None:
             self.clf = LinearSVC(C=1.0, penalty='l1',
-                loss='squared_hinge', dual=False, tol=1e-7)
+                loss='squared_hinge', dual=False, tol=1e-7, max_iter=10000)
         else:
             self.clf = clf
         self.withdp = withdp


### PR DESCRIPTION
- resolves the `Liblinear failed to converge` warning during the final training stage
- increases `max_iter` parameter for the `LinearSVC` model in `dplp_parser/model.py` to `10000` (from 1000 default)